### PR TITLE
skip_after_confirm 거부 사유 기록 개선

### DIFF
--- a/app/workflows/trading.py
+++ b/app/workflows/trading.py
@@ -706,6 +706,7 @@ def _run_confirm_step(
             f"레버리지: {float(leverage)}x\n"
             "레버리지 기준 손실률은 청산 방지를 위해 85%를 넘으면 안 됩니다. 필요시 조정하세요.\n"
             "필수: confirm(boolean). 선택: tp, sl, price, buy_now, leverage, explain.\n"
+            "confirm=false이면 반드시 explain에 거부 사유를 한국어로 작성하세요.\n"
             "확신하면 confirm=true. 수정이 필요하면 값을 조정해 응답하세요."
         )
         confirm = deps.ai_provider.confirm_trade_json(confirm_prompt)
@@ -721,11 +722,15 @@ def _run_confirm_step(
             )
         )
         if not bool(confirm.get("confirm")):
+            skip_reason = str(confirm.get("explain") or "").strip()
+            if not skip_reason:
+                skip_reason = "확인 단계에서 거부 사유가 제공되지 않았습니다."
             _record_skip(
                 deps,
                 reason="skip_after_confirm",
                 decision=decision,
                 meta={"first": decision, "confirm": confirm},
+                reason_text=skip_reason,
             )
             return order_type, entry_price, use_tp, use_sl, leverage, confirm_meta, True
 
@@ -1289,6 +1294,7 @@ def _record_skip(
     reason: str,
     decision: Dict[str, Any],
     meta: Optional[Dict[str, Any]] = None,
+    reason_text: Optional[str] = None,
 ) -> None:
     try:
         deps.store.record_journal(
@@ -1299,7 +1305,7 @@ def _record_skip(
                     {"status": "skip", "reason": reason},
                     ensure_ascii=False,
                 ),
-                "reason": decision.get("explain"),
+                "reason": reason_text or decision.get("explain"),
                 "meta": (
                     {"decision": decision, "details": meta}
                     if meta is not None


### PR DESCRIPTION
## Summary
- confirm 단계 프롬프트에 거부 사유(explain) 작성 요구를 추가했습니다.
- confirm 단계에서 거부된 경우 explain 값을 저널 reason 필드에 기록하도록 조정했습니다.

## Testing
- 테스트를 수행하지 않았습니다.


------
https://chatgpt.com/codex/tasks/task_e_6904865b9b5c8329b3d7c7da67678b4c