### PR TITLE
update_existing 시 거래 기록의 TP/SL 동기화

### DIFF
--- a/app/workflows/trading.py
+++ b/app/workflows/trading.py
@@ -966,6 +966,17 @@ def _handle_update_existing_positions(
             }
         )
 
+        try:
+            if tp_val is not None or applied_sl is not None:
+                deps.store.update_open_trades_tp_sl(
+                    deps.contract_symbol,
+                    side=pos_side,
+                    tp=tp_val,
+                    sl=applied_sl,
+                )
+        except Exception as exc:
+            LOGGER.error("Trade store TP/SL update failed: %s", exc)
+
     if not success:
         LOGGER.error("update_existing 요청으로 TP/SL을 수정하지 못했습니다.")
         _record_skip(


### PR DESCRIPTION
## 요약
- TradeStore에 열린 포지션의 TP/SL을 갱신하는 메서드를 추가했습니다.
- update_existing 흐름에서 거래소 업데이트가 성공하면 로컬 거래 기록도 최신 TP/SL로 동기화하도록 했습니다.

## 테스트
- 없음 (수동 검증)


------
https://chatgpt.com/codex/tasks/task_e_6907831b4c1c8329aa16c1ec6afc4d98