### PR TITLE
스케줄러 실행 간격 조정 및 최신 리뷰 프롬프트 포함

### DIFF
--- a/app/services/journal.py
+++ b/app/services/journal.py
@@ -153,25 +153,23 @@ class JournalService:
         """Return the latest trade reviews as prompt-ready text."""
         try:
             df = self.store.fetch_journals(
-                symbol=contract_symbol, types=["review"], limit=5, ascending=False
+                symbol=contract_symbol, types=["review"], limit=1, ascending=False
             )
             if df is None or getattr(df, "empty", True):
                 return ""
 
-            lines = []
-            for _, row in df.iterrows():
-                ts = row.get("ts")
-                ts_str = (
-                    ts.strftime("%Y-%m-%d %H:%M:%S")
-                    if hasattr(ts, "strftime")
-                    else str(ts)
-                )
-                reason = row.get("reason") or ""
-                content = row.get("content") or ""
-                if len(content) > 500:
-                    content = content[:500]
-                lines.append(f"[{ts_str}] {reason} | {content}")
-            return "\n".join(lines)
+            row = df.iloc[0]
+            ts = row.get("ts")
+            ts_str = (
+                ts.strftime("%Y-%m-%d %H:%M:%S")
+                if hasattr(ts, "strftime")
+                else str(ts)
+            )
+            reason = row.get("reason") or ""
+            content = row.get("content") or ""
+            if len(content) > 500:
+                content = content[:500]
+            return f"[{ts_str}] {reason} | {content}".strip()
         except Exception:
             return ""
 

--- a/app/workflows/trading.py
+++ b/app/workflows/trading.py
@@ -529,8 +529,8 @@ def _build_prompt(deps: AutomationDependencies, ctx: PromptContext) -> str:
         + "\n[/CURRENT_POSITIONS]\n"
     )
 
-    # if ctx.reviews_text:
-    #     prompt += "[RECENT_REVIEWS]\n" + ctx.reviews_text + "\n[/RECENT_REVIEWS]\n"
+    if ctx.reviews_text:
+        prompt += "[RECENT_REVIEWS]\n" + ctx.reviews_text + "\n[/RECENT_REVIEWS]\n"
     # if ctx.recent_reports_text:
     #     prompt += (
     #         "[RECENT_REPORTS]\n" + ctx.recent_reports_text + "\n[/RECENT_REPORTS]\n"

--- a/main.py
+++ b/main.py
@@ -46,10 +46,11 @@ def run_scheduler() -> None:
         except Exception:
             logging.exception("Loss review job error")
 
-    # 매 5분 주기로 실행
-    schedule.every(5).minutes.do(job)
-    # 5분 주기로 실행
-    schedule.every(5).minutes.do(review_job)
+    # 매 정각을 기준으로 3분 간격(0,3,6,...,57분)에 실행
+    for minute in range(0, 60, 3):
+        minute_str = f":{minute:02d}"
+        schedule.every().hour.at(minute_str).do(job)
+        schedule.every().hour.at(minute_str).do(review_job)
 
     # job()
     # review_job()


### PR DESCRIPTION
## 요약
- 스케줄러를 정각 기준 3분 간격(0, 3, ..., 57분)으로 실행되도록 조정했습니다.
- 트레이딩 프롬프트에 동일 심볼의 최신 리뷰 1건이 포함되도록 프롬프트 빌더를 수정했습니다.
- 저널 서비스가 최신 리뷰 1건만 반환하도록 정리했습니다.

## 테스트
- python -m compileall main.py app

------
https://chatgpt.com/codex/tasks/task_e_690785fd82cc83298832d65ca337358f