### PR TITLE
MySQL 연동 강화를 위한 구성 업데이트

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,45 @@
 services:
+  db:
+    image: mysql:8.0
+    container_name: crypto_db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: cryptobot
+      MYSQL_USER: bot
+      MYSQL_PASSWORD: botpass
+    command:
+      [
+        "mysqld",
+        "--default-authentication-plugin=mysql_native_password",
+        "--character-set-server=utf8mb4",
+        "--collation-server=utf8mb4_unicode_ci",
+      ]
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mysqladmin ping -h localhost -uroot -p\"$MYSQL_ROOT_PASSWORD\"",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 30s
+    volumes:
+      - db-data:/var/lib/mysql
+
   app:
     build: .
     user: "1000:1000"
     container_name: crypto_bot
+    depends_on:
+      - db
     env_file:
       - .env
     environment:
+      MYSQL_URL: mysql+pymysql://bot:botpass@db:3306/cryptobot
       SQLITE_PATH: /app/data/trading.sqlite
       APP_BASE_DIR: /app
-      FORCE_SQLITE: "1"
     volumes:
       - ./.env:/app/.env
       - ./trading.log:/app/trading.log
@@ -22,13 +53,14 @@ services:
     container_name: crypto_web
     depends_on:
       - app
+      - db
     env_file:
       - .env
     environment:
       TESTNET: ${TESTNET:-1}
+      MYSQL_URL: mysql+pymysql://bot:botpass@db:3306/cryptobot
       SQLITE_PATH: /app/data/trading.sqlite
       APP_BASE_DIR: /app
-      FORCE_SQLITE: "1"
     ports:
       - "8000:8000"
     command: ["uvicorn", "webapp:app", "--host", "0.0.0.0", "--port", "8000"]
@@ -36,3 +68,6 @@ services:
     volumes:
       - ./.env:/app/.env
       - ./data:/app/data
+
+volumes:
+  db-data:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,7 @@ Confirm 단계에서는 원본 결정 프롬프트와 LLM 응답을 다시 제�
 
 - 모든 거래/저널 기록은 `TradeStore`를 통해 MySQL(기본) 또는 SQLite로 저장됩니다.
 - `StorageConfig.resolve()`가 환경변수에 따라 연결을 결정합니다.
+- MySQL 연결이 실패하면 기본적으로 예외가 발생하며, `ALLOW_SQLITE_FALLBACK=1`을 설정하면 SQLite로 자동 전환할 수 있습니다.
 - `journal_service.review_losing_trades`는 동일 DB를 이용하여 손실 거래를 조회한 뒤 리뷰 기록을 추가합니다.
 
 ## Extension Points

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,8 @@ utils/           # 거래소/AI/저장소 등 기존 래퍼 모듈
    docker compose up -d --build
    ```
 
+   기본 MySQL 접속 정보는 `MYSQL_URL=mysql+pymysql://bot:botpass@db:3306/cryptobot`이며, 컨테이너는 자동으로 초기화됩니다.
+
 ## 주요 환경변수
 
 ```text
@@ -68,9 +70,12 @@ OPENAI_BASE_URL=...
 OPENAI_API_KEY=...
 OPENAI_MODEL=...
 
-# 데이터 저장소 (MySQL 또는 SQLite 폴백)
+# 데이터 저장소 (MySQL 기본 / 옵션)
 MYSQL_URL=mysql+pymysql://bot:botpass@db:3306/cryptobot
 SQLITE_PATH=data/trading.sqlite
+DB_CONNECT_RETRIES=5            # MySQL 연결 재시도 횟수 (선택)
+DB_CONNECT_RETRY_DELAY=2        # 재시도 간격(초)
+ALLOW_SQLITE_FALLBACK=0         # MySQL 실패 시 SQLite 폴백 허용 여부
 ```
 
 ## 스케줄러 동작

--- a/webapp.py
+++ b/webapp.py
@@ -16,11 +16,15 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from dotenv import load_dotenv
+
 from app.core.symbols import parse_trading_symbols, to_ccxt_symbols
 from utils.bybit_utils import BybitUtils
 from utils.storage import TradeStore, StorageConfig
 from utils.ai_provider import AIProvider
 
+
+load_dotenv()
 
 app = FastAPI(title="Crypto Bot UI")
 


### PR DESCRIPTION
## 요약
- Docker Compose에 MySQL 서비스를 추가하고 앱/웹 컨테이너가 기본적으로 MySQL에 연결하도록 환경변수를 정비했습니다.
- TradeStore 초기화 시 MySQL 연결 재시도 및 선택적 SQLite 폴백 제어를 도입해 자동매매와 웹 UI가 동일한 DB를 사용하도록 했습니다.
- .env 로딩과 문서화를 통해 MySQL 설정 방법과 재시도 옵션을 명시했습니다.

## 테스트
- python -m compileall utils/storage.py webapp.py

------
https://chatgpt.com/codex/tasks/task_e_69084d785f84832988c8be65882cbdef