### PR TITLE
반응형 대시보드 및 오버레이 스타일 개선

### DIFF
--- a/static/dashboard.css
+++ b/static/dashboard.css
@@ -149,21 +149,34 @@ a {
   gap: 24px;
 }
 
-.panel-row {
-  display: flex;
-  flex-wrap: wrap;
+.layout-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
   gap: 24px;
+  align-items: start;
 }
 
-.panel-row > .panel {
-  flex: 1 1 340px;
+.layout-column {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
   min-width: 0;
+}
+
+.layout-column--secondary {
+  position: sticky;
+  top: 28px;
+  align-self: flex-start;
 }
 
 .panel-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
   gap: 24px;
+}
+
+.panel-grid--balanced {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
 .panel-grid--wide {
@@ -465,9 +478,9 @@ select:focus {
 }
 
 .journal-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px 14px;
   align-items: center;
   padding: 12px 14px;
   border-radius: var(--radius-md);
@@ -483,14 +496,15 @@ select:focus {
   gap: 8px;
   font-size: 13px;
   color: var(--text-muted);
+  min-width: 0;
 }
 
 .journal-limit select {
-  width: 110px;
+  width: min(150px, 100%);
 }
 
 .journal-sort select {
-  width: 140px;
+  width: min(180px, 100%);
 }
 
 .journal-type-filters {
@@ -501,6 +515,8 @@ select:focus {
   border-radius: var(--radius-md);
   border: 1px solid rgba(148, 163, 184, 0.16);
   background: rgba(15, 23, 42, 0.6);
+  grid-column: 1 / -1;
+  justify-content: flex-start;
 }
 
 .journal-type-label {
@@ -516,6 +532,13 @@ select:focus {
   gap: 6px;
   font-size: 13px;
   color: var(--text);
+}
+
+.journal-controls .btn,
+.journal-controls .btn--ghost {
+  display: flex;
+  width: 100%;
+  justify-content: center;
 }
 
 .journal-type-filters input {
@@ -720,6 +743,14 @@ select:focus {
 }
 
 @media (max-width: 960px) {
+  .layout-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .layout-column--secondary {
+    position: static;
+  }
+
   .page-shell {
     margin: 32px auto;
     padding: 0 20px 40px;
@@ -734,10 +765,6 @@ select:focus {
   .page-meta {
     width: 100%;
     justify-content: flex-start;
-  }
-
-  .panel-row {
-    flex-direction: column;
   }
 
   .panel {
@@ -788,6 +815,7 @@ select:focus {
   }
 
   .journal-controls {
+    display: flex;
     flex-direction: column;
     align-items: stretch;
   }

--- a/static/dashboard.css
+++ b/static/dashboard.css
@@ -260,6 +260,7 @@ a {
   border-radius: var(--radius-md);
   border: 1px solid rgba(148, 163, 184, 0.1);
   background: rgba(11, 16, 28, 0.6);
+  -webkit-overflow-scrolling: touch;
 }
 
 table {
@@ -730,6 +731,11 @@ select:focus {
     padding: 26px;
   }
 
+  .page-meta {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
   .panel-row {
     flex-direction: column;
   }
@@ -766,6 +772,21 @@ select:focus {
     font-size: 26px;
   }
 
+  .panel-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .panel-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .panel-actions .btn,
+  .panel-actions .btn--ghost {
+    width: 100%;
+  }
+
   .journal-controls {
     flex-direction: column;
     align-items: stretch;
@@ -779,7 +800,65 @@ select:focus {
     flex-wrap: wrap;
   }
 
+  .journal-controls > * {
+    width: 100%;
+  }
+
+  .journal-type-filters {
+    justify-content: space-between;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .stats-actions .btn,
+  .stats-actions .btn--ghost {
+    width: 100%;
+  }
+
+  .balance-summary {
+    grid-template-columns: 1fr 1fr;
+  }
+
   table {
     min-width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .page-shell {
+    padding: 0 14px 28px;
+  }
+
+  .card,
+  .panel,
+  .panel-body {
+    padding: 18px;
+  }
+
+  .balance-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .journal-type-filters {
+    gap: 10px;
+  }
+
+  .journal-type-filters label {
+    flex: 1 1 45%;
+  }
+
+  .panel-title {
+    font-size: 18px;
+  }
+
+  .panel-subtitle {
+    font-size: 12px;
   }
 }

--- a/static/overlay.css
+++ b/static/overlay.css
@@ -224,15 +224,18 @@ body {
   body {
     padding: 10px;
     font-size: 15px;
+    overflow: auto;
   }
 
   .overlay-board {
     gap: 10px;
+    flex-direction: column;
   }
 
   .card {
     min-width: calc(100% - 20px);
     max-width: calc(100% - 20px);
+    width: calc(100% - 20px);
   }
 
   .overlay-controls {
@@ -242,5 +245,30 @@ body {
     flex-wrap: wrap;
     border-radius: var(--overlay-radius);
     margin-top: 10px;
+    gap: 10px;
+  }
+
+  .overlay-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .overlay-button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 420px) {
+  body {
+    font-size: 14px;
+  }
+
+  .title {
+    font-size: 1em;
+  }
+
+  .row {
+    flex-direction: column;
+    gap: 4px;
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,181 +31,187 @@
         </div>
       </header>
 
-      <main class="page-main">
-        <section class="panel-row">
-          <article class="card panel panel--stack" id="card-balance">
+      <main class="page-main layout-grid">
+        <div class="layout-column layout-column--primary">
+          <section class="panel-grid panel-grid--balanced">
+            <article class="card panel panel--stack" id="card-balance">
+              <header class="panel-header">
+                <div>
+                  <h2 class="panel-title">잔고 / 포지션</h2>
+                  <p class="panel-subtitle">실시간 자산 현황</p>
+                </div>
+                <div class="panel-actions">
+                  <button
+                    class="btn btn--ghost"
+                    type="button"
+                    id="balance-refresh"
+                  >
+                    새로고침
+                  </button>
+                  <span
+                    class="panel-actions__hint"
+                    id="balance-refresh-hint"
+                  ></span>
+                </div>
+              </header>
+              <div class="panel-body">
+                <div class="balance-summary" id="balance"></div>
+                <div class="table-wrapper" id="positions"></div>
+              </div>
+            </article>
+
+            <article class="card panel" id="card-stats">
+              <header class="panel-header">
+                <div>
+                  <h2 class="panel-title">통계</h2>
+                  <p class="panel-subtitle">기간별 성과를 비교해 보세요.</p>
+                </div>
+              </header>
+              <div class="panel-body">
+                <div class="stats-grid">
+                  <div class="input-field">
+                    <label for="st-since">시작 (UTC YYYY-MM-DD)</label>
+                    <input id="st-since" placeholder="2025-01-01" />
+                  </div>
+                  <div class="input-field">
+                    <label for="st-until">종료 (UTC YYYY-MM-DD)</label>
+                    <input id="st-until" placeholder="2025-12-31" />
+                  </div>
+                  <div class="input-field">
+                    <label for="st-symbol">심볼 (선택)</label>
+                    <select id="st-symbol">
+                      <option value="">전체</option>
+                    </select>
+                  </div>
+                  <div class="input-field">
+                    <label for="st-group">그룹</label>
+                    <select id="st-group">
+                      <option value="">없음</option>
+                      <option value="day">일별</option>
+                      <option value="week">주별</option>
+                      <option value="month">월별</option>
+                    </select>
+                  </div>
+                </div>
+                <div class="stats-actions">
+                  <button class="btn btn--ghost" id="st-refresh">조회</button>
+                  <button class="btn" id="st-today">오늘</button>
+                  <button class="btn" id="st-this-month">이번 달</button>
+                  <button class="btn" id="st-last-7d">최근 7일</button>
+                </div>
+                <div class="stats-output" id="stats"></div>
+              </div>
+            </article>
+          </section>
+
+          <article class="card panel" id="card-review-pending">
             <header class="panel-header">
               <div>
-                <h2 class="panel-title">잔고 / 포지션</h2>
-                <p class="panel-subtitle">실시간 자산 현황</p>
-              </div>
-              <div class="panel-actions">
-                <button
-                  class="btn btn--ghost"
-                  type="button"
-                  id="balance-refresh"
-                >
-                  새로고침
-                </button>
-                <span
-                  class="panel-actions__hint"
-                  id="balance-refresh-hint"
-                ></span>
+                <h2 class="panel-title">리뷰 대기열</h2>
+                <p class="panel-subtitle">청산 후 4시간 대기 중인 포지션</p>
               </div>
             </header>
             <div class="panel-body">
-              <div class="balance-summary" id="balance"></div>
-              <div class="table-wrapper" id="positions"></div>
+              <div class="table-wrapper" id="pending-reviews"></div>
             </div>
           </article>
+        </div>
 
-          <article class="card panel" id="card-stats">
+        <aside class="layout-column layout-column--secondary">
+          <section class="card panel">
             <header class="panel-header">
               <div>
-                <h2 class="panel-title">통계</h2>
-                <p class="panel-subtitle">기간별 성과를 비교해 보세요.</p>
+                <h2 class="panel-title">저널 조회</h2>
+                <p class="panel-subtitle">
+                  오늘 생성된 최신 기록을 시간순으로 확인하세요.
+                </p>
               </div>
             </header>
             <div class="panel-body">
-              <div class="stats-grid">
-                <div class="input-field">
-                  <label for="st-since">시작 (UTC YYYY-MM-DD)</label>
-                  <input id="st-since" placeholder="2025-01-01" />
-                </div>
-                <div class="input-field">
-                  <label for="st-until">종료 (UTC YYYY-MM-DD)</label>
-                  <input id="st-until" placeholder="2025-12-31" />
-                </div>
-                <div class="input-field">
-                  <label for="st-symbol">심볼 (선택)</label>
-                  <select id="st-symbol">
+              <div class="journal-controls">
+                <label class="journal-limit">
+                  페이지당 개수
+                  <select id="jr-limit">
+                    <option value="10">10개</option>
+                    <option value="30" selected>30개</option>
+                    <option value="50">50개</option>
+                    <option value="100">100개</option>
+                  </select>
+                </label>
+                <label class="journal-limit">
+                  타임존
+                  <select id="tz-select">
+                    <option value="UTC">UTC</option>
+                    <option value="UTC+9" selected>UTC+9</option>
+                    <option value="UTC+1">UTC+1</option>
+                    <option value="UTC-5">UTC-5</option>
+                  </select>
+                </label>
+                <label class="journal-limit">
+                  코인
+                  <select id="jr-symbol">
                     <option value="">전체</option>
                   </select>
-                </div>
-                <div class="input-field">
-                  <label for="st-group">그룹</label>
-                  <select id="st-group">
-                    <option value="">없음</option>
-                    <option value="day">일별</option>
-                    <option value="week">주별</option>
-                    <option value="month">월별</option>
+                </label>
+                <label class="journal-sort">
+                  정렬
+                  <select id="jr-sort">
+                    <option value="desc" selected>최신순</option>
+                    <option value="asc">오래된순</option>
                   </select>
+                </label>
+                <label class="journal-sort">
+                  기간
+                  <select id="jr-range">
+                    <option value="today">오늘</option>
+                    <option value="recent15" selected>최근 15분</option>
+                  </select>
+                </label>
+                <div id="jr-type-filters" class="journal-type-filters">
+                  <span class="journal-type-label">유형</span>
+                  <label
+                    ><input type="checkbox" value="decision" checked />판단</label
+                  >
+                  <label
+                    ><input type="checkbox" value="action" checked />액션</label
+                  >
+                  <label
+                    ><input type="checkbox" value="review" checked />리뷰</label
+                  >
+                  <label
+                    ><input type="checkbox" value="error" checked />오류</label
+                  >
                 </div>
+                <div id="jr-status-filters" class="journal-type-filters">
+                  <span class="journal-type-label">포지션</span>
+                  <label><input type="checkbox" value="long" checked />롱</label>
+                  <label
+                    ><input type="checkbox" value="hold" checked />홀딩</label
+                  >
+                  <label><input type="checkbox" value="short" checked />숏</label>
+                </div>
+                <button class="btn btn--ghost" id="jr-refresh">조회</button>
+                <button class="btn btn--ghost" id="jr-reset">초기화</button>
+                <a
+                  class="btn"
+                  href="/overlay?limit=12&today_only=1&ascending=0&types=decision,action,review"
+                  target="_blank"
+                >
+                  판단 오버레이
+                </a>
+                <a
+                  class="btn"
+                  href="/overlay_positions?refresh=5&fs=18"
+                  target="_blank"
+                >
+                  포지션 오버레이
+                </a>
               </div>
-              <div class="stats-actions">
-                <button class="btn btn--ghost" id="st-refresh">조회</button>
-                <button class="btn" id="st-today">오늘</button>
-                <button class="btn" id="st-this-month">이번 달</button>
-                <button class="btn" id="st-last-7d">최근 7일</button>
-              </div>
-              <div class="stats-output" id="stats"></div>
+              <div class="table-wrapper" id="journals"></div>
+              <div class="journal-pagination" id="jr-pagination" hidden></div>
             </div>
-          </article>
-        </section>
-
-        <article class="card panel" id="card-review-pending">
-          <header class="panel-header">
-            <div>
-              <h2 class="panel-title">리뷰 대기열</h2>
-              <p class="panel-subtitle">청산 후 4시간 대기 중인 포지션</p>
-            </div>
-          </header>
-          <div class="panel-body">
-            <div class="table-wrapper" id="pending-reviews"></div>
-          </div>
-        </article>
-
-        <section class="card panel">
-          <header class="panel-header">
-            <div>
-              <h2 class="panel-title">저널 조회</h2>
-              <p class="panel-subtitle">
-                오늘 생성된 최신 기록을 시간순으로 확인하세요.
-              </p>
-            </div>
-          </header>
-          <div class="panel-body">
-            <div class="journal-controls">
-              <label class="journal-limit">
-                페이지당 개수
-                <select id="jr-limit">
-                  <option value="10">10개</option>
-                  <option value="30" selected>30개</option>
-                  <option value="50">50개</option>
-                  <option value="100">100개</option>
-                </select>
-              </label>
-              <label class="journal-limit">
-                타임존
-                <select id="tz-select">
-                  <option value="UTC">UTC</option>
-                  <option value="UTC+9" selected>UTC+9</option>
-                  <option value="UTC+1">UTC+1</option>
-                  <option value="UTC-5">UTC-5</option>
-                </select>
-              </label>
-              <label class="journal-limit">
-                코인
-                <select id="jr-symbol">
-                  <option value="">전체</option>
-                </select>
-              </label>
-              <label class="journal-sort">
-                정렬
-                <select id="jr-sort">
-                  <option value="desc" selected>최신순</option>
-                  <option value="asc">오래된순</option>
-                </select>
-              </label>
-              <label class="journal-sort">
-                기간
-                <select id="jr-range">
-                  <option value="today">오늘</option>
-                  <option value="recent15" selected>최근 15분</option>
-                </select>
-              </label>
-              <div id="jr-type-filters" class="journal-type-filters">
-                <span class="journal-type-label">유형</span>
-                <label
-                  ><input type="checkbox" value="decision" checked />판단</label
-                >
-                <label
-                  ><input type="checkbox" value="action" checked />액션</label
-                >
-                <label
-                  ><input type="checkbox" value="review" checked />리뷰</label
-                >
-                <label
-                  ><input type="checkbox" value="error" checked />오류</label
-                >
-              </div>
-              <div id="jr-status-filters" class="journal-type-filters">
-                <span class="journal-type-label">포지션</span>
-                <label><input type="checkbox" value="long" checked />롱</label>
-                <label
-                  ><input type="checkbox" value="hold" checked />홀딩</label
-                >
-                <label><input type="checkbox" value="short" checked />숏</label>
-              </div>
-              <button class="btn btn--ghost" id="jr-refresh">조회</button>
-              <button class="btn btn--ghost" id="jr-reset">초기화</button>
-              <a
-                class="btn"
-                href="/overlay?limit=12&today_only=1&ascending=0&types=decision,action,review"
-                target="_blank"
-                >판단 오버레이</a
-              >
-              <a
-                class="btn"
-                href="/overlay_positions?refresh=5&fs=18"
-                target="_blank"
-                >포지션 오버레이</a
-              >
-            </div>
-            <div class="table-wrapper" id="journals"></div>
-            <div class="journal-pagination" id="jr-pagination" hidden></div>
-          </div>
-        </section>
+          </section>
+        </aside>
       </main>
     </div>
   </body>


### PR DESCRIPTION
## 요약
- 대시보드 카드, 패널, 통계 컨트롤의 레이아웃을 모바일 뷰포트에서 수직으로 재배치하여 사용성을 향상했습니다.
- 테이블 및 저널 필터 UI의 가로 스크롤과 터치 상호작용을 개선하고 작은 화면 전용 타이포그래피를 조정했습니다.
- 오버레이 화면의 카드, 컨트롤 버튼을 세로 흐름으로 정렬하고 초소형 화면에서 가독성을 확보했습니다.

## 테스트
- 스타일 변경으로 별도 테스트 없음


------
https://chatgpt.com/codex/tasks/task_e_690b1fe11e488329812d585ee77d9b63