### PR TITLE
리뷰 대기 시간 48시간 반영

### DIFF
--- a/app/services/journal.py
+++ b/app/services/journal.py
@@ -299,7 +299,7 @@ class JournalService:
     def list_pending_reviews(
         self,
         *,
-        wait_hours: int = 4,
+        wait_hours: int = 48,
         since_hours: int = 24,
     ) -> list[dict[str, object]]:
         """Return closed-loss trades waiting for review availability."""

--- a/templates/index.html
+++ b/templates/index.html
@@ -108,7 +108,7 @@
             <header class="panel-header">
               <div>
                 <h2 class="panel-title">리뷰 대기열</h2>
-                <p class="panel-subtitle">청산 후 4시간 대기 중인 포지션</p>
+                <p class="panel-subtitle">청산 후 48시간 대기 중인 포지션</p>
               </div>
             </header>
             <div class="panel-body">

--- a/webapp.py
+++ b/webapp.py
@@ -426,7 +426,7 @@ def list_journals(
 
 
 @app.get("/api/reviews/pending")
-def list_pending_reviews(wait_hours: int = 4, since_hours: int = 24):
+def list_pending_reviews(wait_hours: int = 48, since_hours: int = 24):
     try:
         safe_wait = max(0, int(wait_hours))
     except Exception:


### PR DESCRIPTION
## 요약
- 손실 리뷰 대기열 기본 대기 시간을 48시간으로 변경했습니다.
- 웹 인터페이스에서 대기 시간 안내 문구를 48시간으로 갱신했습니다.

## 테스트
- 해당 없음

------
https://chatgpt.com/codex/tasks/task_e_690b66c869a48329a1ab0636a1768550