### PR TITLE
통계 범위 조회 시 자동 청산 거래 보정

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -243,6 +243,12 @@ def stats_range(
             sqlite_path=os.getenv("SQLITE_PATH"),
         )
     )
+    # 자동 청산(TP/SL)으로 인해 통계에서 누락되는 건을 방지하기 위해
+    # stats_range 조회 시에도 보정 로직을 실행한다.
+    try:
+        _reconcile_auto_closed_positions(store)
+    except Exception:
+        pass
 
     def _parse_iso(ts: Optional[str]):
         if not ts:


### PR DESCRIPTION
## 요약
- stats_range 엔드포인트에서도 자동 청산(TP/SL) 보정 로직을 실행하여 손절 청산이 통계에서 누락되지 않도록 함

## 테스트
- python -m compileall webapp.py

------
https://chatgpt.com/codex/tasks/task_e_690c13f8b5908329b480eff14355f69c